### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 [![Build Status](https://travis-ci.org/szaghi/PreForM.png)](https://travis-ci.org/szaghi/PreForM)
-[![Latest Version](https://pypip.in/version/PreForM.py/badge.svg)](https://pypi.python.org/pypi/PreForM.py/)
-[![Downloads](https://pypip.in/download/PreForM.py/badge.svg)](https://pypi.python.org/pypi/PreForM.py/)
-[![Supported Python versions](https://pypip.in/py_versions/PreForM.py/badge.svg)](https://pypi.python.org/pypi/PreForM.py/)
-[![Development Status](https://pypip.in/status/PreForM.py/badge.svg)](https://pypi.python.org/pypi/PreForM.py/)
-[![License](https://pypip.in/license/PreForM.py/badge.svg)](https://pypi.python.org/pypi/PreForM.py/)
+[![Latest Version](https://img.shields.io/pypi/v/PreForM.py.svg)](https://pypi.python.org/pypi/PreForM.py/)
+[![Downloads](https://img.shields.io/pypi/dm/PreForM.py.svg)](https://pypi.python.org/pypi/PreForM.py/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/PreForM.py.svg)](https://pypi.python.org/pypi/PreForM.py/)
+[![Development Status](https://img.shields.io/pypi/status/PreForM.py.svg)](https://pypi.python.org/pypi/PreForM.py/)
+[![License](https://img.shields.io/pypi/l/PreForM.py.svg)](https://pypi.python.org/pypi/PreForM.py/)
 
 # PreForM.py
 ### <a name="top">PreForM.py,  Preprocessor for Fortran poor Men


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20preform-py))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `preform-py`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.